### PR TITLE
Remove properties oneOf, allOf, anyOf and not and not from ObjectSchema and ArraySchema

### DIFF
--- a/src/December2020/Generator.php
+++ b/src/December2020/Generator.php
@@ -17,6 +17,7 @@ use Giann\Schematics\December2020\StringSchema;
 use Giann\Schematics\December2020\Type;
 use Giann\Schematics\Exception\InvalidSchemaException;
 use Giann\Schematics\Exception\InvalidSchemaKeywordValueException;
+use Giann\Schematics\Exception\InvalidSchemaTypeException;
 use Giann\Schematics\GeneratorHelper;
 use Giann\Trunk\Trunk;
 use PhpParser\Node\Arg;
@@ -282,6 +283,20 @@ class Generator
                         throw new InvalidSchemaKeywordValueException(
                             '`' . $property . '` must be a Schema[] at ' . $path
                         );
+                    }
+
+                    if (isset($rawSchema['type'])) {
+                        foreach ($subs as &$sub) {
+                            if (
+                                !array_key_exists('type', $sub->arrayRawValue()) &&
+                                !array_key_exists('$ref', $sub->arrayRawValue())
+                            ) {
+                                $sub = new Trunk(array_merge(
+                                    ['type' => $rawSchema['type']->stringValue()],
+                                    $sub->arrayRawValue()
+                                ));
+                            }
+                        }
                     }
 
                     $parameters[] = new Arg(

--- a/src/December2020/Schema.php
+++ b/src/December2020/Schema.php
@@ -104,18 +104,44 @@ class Schema implements JsonSerializable
         ?string $enumClass = null,
     ) {
         if ($this->enum === null && $enumClass !== null) {
-            $this->enum = array_merge($this->enum ?? [], self::classToEnum($enumClass));
+            $this->enum = self::classToEnum($enumClass);
         }
 
         if ($this->enum === null && $enumPattern !== null) {
-            $this->enum = array_merge($this->enum ?? [], self::patternToEnum($enumPattern) ?? []);
+            $this->enum = self::patternToEnum($enumPattern) ?? [];
+        }
+    }
+
+
+    /**
+     * @throws InvalidSchemaTypeException
+     */
+    public function validate(): bool
+    {
+        if (!empty($this->type)) {
+            foreach (['oneOf', 'anyOf', 'allOf'] as $property) {
+                if (($this->{$property} ?? []) !== []) {
+                    /** @var \Giann\Schematics\December2020\Schema $child */
+                    foreach ($this->{$property} as $index => $child) {
+                        if (empty($child->type) && $child->ref !== null) {
+                            continue;
+                        }
+
+                        if ($this->type !== $child->type) {
+                            throw new InvalidSchemaTypeException(
+                                'Property ' . $property . '/' . $index .
+                                ' has an inconsistent type from its parent, expecting type [ ' .
+                                implode(', ', array_map(fn (Type $type) => $type->value, $this->type)). ' ]' .
+                                ' but got type [ ' .
+                                implode(', ', array_map(fn (Type $type) => $type->value, $child->type)). ' ]'
+                            );
+                        }
+                    }
+                }
+            }
         }
 
-        if (!empty($this->type)) {
-            $this->validateTypeInheritance('oneOf');
-            $this->validateTypeInheritance('anyOf');
-            $this->validateTypeInheritance('allOf');
-        }
+        return true;
     }
 
     public function getResolvedRef(): ?string
@@ -716,30 +742,5 @@ class Schema implements JsonSerializable
             + ($this->if !== null ? ['if' => $this->if->jsonSerialize()] : [])
             + ($this->then !== null ? ['then' => $this->then->jsonSerialize()] : [])
             + ($this->else !== null ? ['else' => $this->else->jsonSerialize()] : []);
-    }
-
-    /**
-     * @throws InvalidSchemaTypeException
-     */
-    protected function validateTypeInheritance(string $property): void
-    {
-        if (($this->{$property} ?? []) !== []) {
-            /** @var Schema $child */
-            foreach ($this->{$property} as $index => $child) {
-                if (empty($child->type) && $child->ref !== null) {
-                    continue;
-                }
-
-                if ($this->type !== $child->type) {
-                    throw new InvalidSchemaTypeException(
-                        'Property ' . $property . '/' . $index .
-                        ' has an inconsistent type from its parent, expecting type [ ' .
-                        implode(', ', array_map(fn (Type $type) => $type->value, $this->type)). ' ]' .
-                        ' but got type [ ' .
-                        implode(', ', array_map(fn (Type $type) => $type->value, $child->type)). ' ]'
-                    );
-                }
-            }
-        }
     }
 }

--- a/src/Draft04/Generator.php
+++ b/src/Draft04/Generator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Giann\Schematics\Draft04;
 
+use Exception;
 use Giann\Schematics\Draft04\ArraySchema;
 use Giann\Schematics\Draft04\BooleanSchema;
 use Giann\Schematics\Draft04\ContentEncoding;
@@ -16,6 +17,7 @@ use Giann\Schematics\Draft04\StringSchema;
 use Giann\Schematics\Draft04\Type;
 use Giann\Schematics\Exception\InvalidSchemaException;
 use Giann\Schematics\Exception\InvalidSchemaKeywordValueException;
+use Giann\Schematics\Exception\InvalidSchemaTypeException;
 use Giann\Schematics\GeneratorHelper;
 use Giann\Trunk\Trunk;
 use PhpParser\Node\Arg;
@@ -277,6 +279,20 @@ class Generator
                         throw new InvalidSchemaKeywordValueException(
                             '`' . $property . '` must be a Schema[] at ' . $path
                         );
+                    }
+
+                    if (isset($rawSchema['type'])) {
+                        foreach ($subs as &$sub) {
+                            if (
+                                !array_key_exists('type', $sub->arrayRawValue()) &&
+                                !array_key_exists('$ref', $sub->arrayRawValue())
+                            ) {
+                                $sub = new Trunk(array_merge(
+                                    ['type' => $rawSchema['type']->stringValue()],
+                                    $sub->arrayRawValue()
+                                ));
+                            }
+                        }
                     }
 
                     $parameters[] = new Arg(

--- a/src/Exception/InvalidSchemaTypeException.php
+++ b/src/Exception/InvalidSchemaTypeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Giann\Schematics\Exception;
+
+class InvalidSchemaTypeException extends InvalidSchemaException
+{
+}

--- a/tests/GenerateJsonSchemaTest.php
+++ b/tests/GenerateJsonSchemaTest.php
@@ -356,6 +356,7 @@ final class GenerateJsonSchemaTest extends TestCase
         // Generate annotation expression AST from json schema
         $ast = (new Generator)->generateSchema(Schema::classSchema(Hero::class)->jsonSerialize());
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
 
         // Compare generated annotations schema to schema built from classes
         $this->assertInstanceOf(Schema::class, $reconstructed);
@@ -410,7 +411,9 @@ final class GenerateJsonSchemaTest extends TestCase
 
         $this->expectException(InvalidSchemaTypeException::class);
         $this->expectExceptionMessage('Property oneOf/0 has an inconsistent type from its parent, expecting type [ object ] but got type [ array ]');
-        eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        /** @var Schema $reconstructed */
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
     }
 
     public function testValidInheritanceTypeSchema(): void
@@ -431,6 +434,7 @@ final class GenerateJsonSchemaTest extends TestCase
         );
 
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
         $this->assertInstanceOf(NumberSchema::class, $reconstructed);
         $this->assertNotNull($reconstructed->oneOf);
         foreach ($reconstructed->oneOf as $definition) {
@@ -463,6 +467,7 @@ final class GenerateJsonSchemaTest extends TestCase
         );
 
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
         $this->assertInstanceOf(ObjectSchema::class, $reconstructed);
         $this->assertNotNull($reconstructed->oneOf);
         foreach ($reconstructed->oneOf as $definition) {
@@ -591,6 +596,7 @@ final class GenerateJsonSchemaTest extends TestCase
         // Generate annotation expression AST from json schema
         $ast = (new Generator)->generateSchema(Draft04Schema::classSchema(Hero04::class)->jsonSerialize());
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
 
         // Compare generated annotations schema to schema built from classes
         $this->assertInstanceOf(Draft04Schema::class, $reconstructed);
@@ -645,7 +651,9 @@ final class GenerateJsonSchemaTest extends TestCase
 
         $this->expectException(InvalidSchemaTypeException::class);
         $this->expectExceptionMessage('Property oneOf/0 has an inconsistent type from its parent, expecting type [ object ] but got type [ array ]');
-        eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        /** @var Schema $reconstructed */
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
     }
 
     public function testDraft04ValidInheritanceTypeSchema(): void
@@ -666,6 +674,7 @@ final class GenerateJsonSchemaTest extends TestCase
         );
 
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
         $this->assertInstanceOf(Draft04NumberSchema::class, $reconstructed);
         $this->assertNotNull($reconstructed->oneOf);
         foreach ($reconstructed->oneOf as $definition) {
@@ -698,6 +707,7 @@ final class GenerateJsonSchemaTest extends TestCase
         );
 
         $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $reconstructed->validate();
         $this->assertInstanceOf(Draft04ObjectSchema::class, $reconstructed);
         $this->assertNotNull($reconstructed->oneOf);
         foreach ($reconstructed->oneOf as $definition) {

--- a/tests/GenerateJsonSchemaTest.php
+++ b/tests/GenerateJsonSchemaTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Giann\Schematics\December2020\NumberSchema;
+use Giann\Schematics\Exception\InvalidSchemaTypeException;
 use PHPUnit\Framework\TestCase;
 use PhpParser\PrettyPrinter;
 use Giann\Schematics\December2020\ArraySchema;
@@ -22,7 +24,7 @@ use Giann\Schematics\Draft04\ArraySchema as Draft04ArraySchema;
 use Giann\Schematics\Draft04\BooleanSchema as Draft04BooleanSchema;
 use Giann\Schematics\Draft04\EntityGenerator as Draft04EntityGenerator;
 use Giann\Schematics\Draft04\IntegerSchema as Draft04IntegerSchema;
-use Giann\Schematics\Draft04\NumberSchema;
+use Giann\Schematics\Draft04\NumberSchema as Draft04NumberSchema;
 use Giann\Schematics\Draft04\ObjectSchema as Draft04ObjectSchema;
 use Giann\Schematics\Draft04\Property\Description as PropertyDescription;
 use Giann\Schematics\Draft04\Schema as Draft04Schema;
@@ -382,6 +384,92 @@ final class GenerateJsonSchemaTest extends TestCase
         );
     }
 
+    public function testInvalidInheritanceTypeSchema(): void
+    {
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::December2020->value,
+                'type' => 'object',
+                'oneOf' => [
+                    [
+                        'type' => 'array',
+                        'maxItems' => 0,
+                    ],
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'interest' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ]
+                ]
+            ]
+        );
+
+        $this->expectException(InvalidSchemaTypeException::class);
+        $this->expectExceptionMessage('Property oneOf/0 has an inconsistent type from its parent, expecting type [ object ] but got type [ array ]');
+        eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+    }
+
+    public function testValidInheritanceTypeSchema(): void
+    {
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::December2020->value,
+                'type' => 'number',
+                'oneOf' => [
+                    [
+                        'multipleOf' => 5,
+                    ],
+                    [
+                        'multipleOf' => 3,
+                    ]
+                ]
+            ]
+        );
+
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $this->assertInstanceOf(NumberSchema::class, $reconstructed);
+        $this->assertNotNull($reconstructed->oneOf);
+        foreach ($reconstructed->oneOf as $definition) {
+            $this->assertInstanceOf(NumberSchema::class, $definition);
+        }
+
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::December2020->value,
+                'type' => 'object',
+                'oneOf' => [
+                    [
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'benefit' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ],
+                    [
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'interest' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ]
+                ]
+            ]
+        );
+
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $this->assertInstanceOf(ObjectSchema::class, $reconstructed);
+        $this->assertNotNull($reconstructed->oneOf);
+        foreach ($reconstructed->oneOf as $definition) {
+            $this->assertInstanceOf(ObjectSchema::class, $definition);
+        }
+    }
+
     public function testInvalidSchema(): void
     {
         try {
@@ -529,5 +617,91 @@ final class GenerateJsonSchemaTest extends TestCase
                 true
             ),
         );
+    }
+
+    public function testDraft04InvalidInheritanceTypeSchema(): void
+    {
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::Draft04->value,
+                'type' => 'object',
+                'oneOf' => [
+                    [
+                        'type' => 'array',
+                        'maxItems' => 0,
+                    ],
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'interest' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ]
+                ]
+            ]
+        );
+
+        $this->expectException(InvalidSchemaTypeException::class);
+        $this->expectExceptionMessage('Property oneOf/0 has an inconsistent type from its parent, expecting type [ object ] but got type [ array ]');
+        eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+    }
+
+    public function testDraft04ValidInheritanceTypeSchema(): void
+    {
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::Draft04->value,
+                'type' => 'number',
+                'oneOf' => [
+                    [
+                        'multipleOf' => 5,
+                    ],
+                    [
+                        'multipleOf' => 3,
+                    ]
+                ]
+            ]
+        );
+
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $this->assertInstanceOf(Draft04NumberSchema::class, $reconstructed);
+        $this->assertNotNull($reconstructed->oneOf);
+        foreach ($reconstructed->oneOf as $definition) {
+            $this->assertInstanceOf(Draft04NumberSchema::class, $definition);
+        }
+
+        $ast = (new Generator)->generateSchema(
+            [
+                '$schema' => Draft::Draft04->value,
+                'type' => 'object',
+                'oneOf' => [
+                    [
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'benefit' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ],
+                    [
+                        'properties' => [
+                            'name' => ['type' => 'string'],
+                            'interest' => ['type' => 'number'],
+                        ],
+                        'additionalProperties' => false,
+                        'required' => ['interest'],
+                    ]
+                ]
+            ]
+        );
+
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+        $this->assertInstanceOf(Draft04ObjectSchema::class, $reconstructed);
+        $this->assertNotNull($reconstructed->oneOf);
+        foreach ($reconstructed->oneOf as $definition) {
+            $this->assertInstanceOf(Draft04ObjectSchema::class, $definition);
+        }
     }
 }


### PR DESCRIPTION
feat: Remove properties oneOf, allOf, anyOf and not from ObjectSchema and ArraySchema. Those properties must be used with class Schema instead

Technically, it's possible to combine a key oneOf and a type in a JSON Schema. But on the other end, leaving this possibility could lead to inconsistent results.
https://json-schema.org/understanding-json-schema/reference/combining#factoringschemas

For exemple, the following schematics is not wrong but its generation is not correct either.

```php
new ObjectSchema(
    oneOf: [
        new ArraySchema(maxItems: 0),
        new ObjectSchema(patternProperties: [
            '.*' => new ObjectSchema(
                properties: [
                    'name' => new StringSchema(),
                    'interest' => new NumberSchema(),
                ],
                additionalProperties: false,
                required: ['interest']
            )
        ]
    ]
)
``` 

```json
{
    "type": "object",
    "oneOf": [
        {
            "type": "array",
            "maxItems": 0
        },
        {
            "type": "object",
            "patternProperties": {
                ".*": {
                    "type": "object",
                    "properties": {
                        "name": {
                            "type": "string"
                        },
                        "interest": {
                            "type": "number"
                        }
                    },
                    "additionalProperties": false,
                    "required": [
                        "interest"
                    ]
                }
            }
        }
    ]
}
```

The parent type **object** is incompatible with the child type **array** but nothing warn us about this.
Either it's possible to throw an exception when a children has an inconsistent type from its parent when using **oneOf**, **anyOf** and **allOf** OR we just remove the possibility to include these keys into an ArraySchema and ObjectSchema.

Instead we would need to implement the following schema :

```php
new Schema(
    oneOf: [
        new ArraySchema(maxItems: 0),
        new ObjectSchema(patternProperties: [
            '.*' => new ObjectSchema(
                properties: [
                    'name' => new StringSchema(),
                    'interest' => new NumberSchema(),
                ],
                additionalProperties: false,
                required: ['interest']
            )
        ]
    ]
)
``` 

I have the same reflection about **not** property, that should not be applied using ObjectSchema or ArraySchema but only with Schema : https://json-schema.org/understanding-json-schema/reference/combining#not