### PR TITLE
feat: improve union types

### DIFF
--- a/src/Draft04/Schema.php
+++ b/src/Draft04/Schema.php
@@ -557,6 +557,9 @@ class Schema implements JsonSerializable
                 case 'stdClass':
                     $propertySchema = new ObjectSchema();
                     break;
+                case 'null':
+                    $propertySchema = new NullSchema();
+                    break;
                 case 'mixed':
                     $propertySchema = new Schema();
                     break;
@@ -604,7 +607,7 @@ class Schema implements JsonSerializable
                     }
             }
 
-            if ($typeReflection->allowsNull()) {
+            if ($typeReflection->allowsNull() && $typeReflection->getName() !== 'null') {
                 $propertySchema = new Schema(
                     oneOf: [
                         new NullSchema(),
@@ -617,13 +620,13 @@ class Schema implements JsonSerializable
         }
 
         if ($typeReflection instanceof ReflectionUnionType) {
-            $oneOf = [];
+            $anyOf = [];
             foreach ($typeReflection->getTypes() as $subTypeReflection) {
-                $oneOf[] = static::inferType($current, $root, $currentClassReflection, $subTypeReflection);
+                $anyOf[] = static::inferType($current, $root, $currentClassReflection, $subTypeReflection);
             }
 
             return new Schema(
-                oneOf: $oneOf
+                anyOf: $anyOf
             );
         }
 

--- a/tests/GenerateJsonSchemaTest.php
+++ b/tests/GenerateJsonSchemaTest.php
@@ -273,6 +273,14 @@ final class ForceInfer
     }
 }
 
+final class ForceInferNullableUnion
+{
+    public function __construct(
+        public float|int|null $value,
+    ) {
+    }
+}
+
 final class GenerateJsonSchemaTest extends TestCase
 {
     public function testBasicSchema(): void
@@ -588,7 +596,7 @@ final class GenerateJsonSchemaTest extends TestCase
                         ],
                         'height' => [
                             'default' => 180,
-                            'oneOf' => [
+                            'anyOf' => [
                                 [
                                     'type' => 'string'
                                 ],
@@ -800,6 +808,50 @@ final class GenerateJsonSchemaTest extends TestCase
         $this->assertEquals(
             $rawSchema,
             Draft04Schema::classSchema(ForceInfer::class, forceInfer: true)->jsonSerialize(),
+        );
+    }
+
+    public function testForceInferNullableUnion04(): void
+    {
+        $rawSchema = [
+            '$schema' => Draft::Draft04->value,
+            'type' => 'object',
+            'properties' => [
+                'value' => [
+                    'anyOf' => [
+                        [
+                            'type' => 'integer'
+                        ],
+                        [
+                            'type' => 'number'
+                        ],
+                        [
+                            'type' => 'null'
+                        ],
+                    ]
+                ]
+            ],
+            'required' => [ 'value' ]
+        ];
+
+        $this->assertEquals(
+            $rawSchema,
+            Draft04Schema::classSchema(ForceInferNullableUnion::class, forceInfer: true)->jsonSerialize(),
+        );
+
+        $ast = (new Generator)->generateSchema($rawSchema);
+        $reconstructed = eval('return ' . (new PrettyPrinter\Standard())->prettyPrintExpr($ast) . ';');
+
+        $this->assertInstanceOf(Draft04Schema::class, $reconstructed);
+        $this->assertEquals($rawSchema, $reconstructed->jsonSerialize());
+
+        $entities = (new Draft04EntityGenerator(new Trunk($rawSchema), namespace: 'Test'))->generateEntities(ForceInferNullableUnion::class);
+
+        eval((new PrettyPrinter\Standard())->prettyPrint($entities));
+
+        $this->assertEquals(
+            $rawSchema,
+            Draft04Schema::classSchema(Test\ForceInferNullableUnion::class, forceInfer: true)->jsonSerialize(),
         );
     }
 }


### PR DESCRIPTION
[improve-union-types]
- allow null type
- replace union oneOf by anyOf to prevent integer / number overlap for int|float typing